### PR TITLE
Added Endpoints for Google Places API for Search and Details

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -14,6 +14,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/backend/controllers/GooglePlacesAPI.ts
+++ b/backend/controllers/GooglePlacesAPI.ts
@@ -1,0 +1,64 @@
+import {AxiosError, AxiosResponse} from "axios";
+
+class GooglePlacesAPI {
+
+    constructor() {
+        require('dotenv').config();
+    }
+
+    getGooglePlacesSearch(data: string): Promise<AxiosResponse<JSON>> {
+        let dataURI: string = encodeURIComponent(data);
+        let axios = require('axios');
+
+        return axios.get('https://maps.googleapis.com/maps/api/place/findplacefromtext/json?'
+            + 'input=' + dataURI
+            + '&inputtype=textquery'
+            + '&fields=formatted_address,name,icon,place_id,types,photos'
+            + '&key=' + process.env.GOOGLE_PLACES_API_KEY
+        )
+            .then((response: AxiosResponse) => {
+
+                let result: JSON = response.data
+                return Promise.resolve(result);
+
+            })
+            .catch((err: AxiosError) => {
+
+                //Google API error message
+                console.log(err?.response?.data?.error)
+
+                //Axios entire error message
+                console.log(err)
+
+                return Promise.reject(err);
+            });
+    }
+
+    getGooglePlacesDetails(placeID: string): Promise<AxiosResponse<JSON>> {
+        let axios = require('axios');
+
+        return axios.get('https://maps.googleapis.com/maps/api/place/details/json?'
+            + 'place_id=' + placeID
+            + '&fields=business_status,url'
+            + '&key=' + process.env.GOOGLE_PLACES_API_KEY
+        )
+            .then((response: AxiosResponse) => {
+
+                let result: JSON = response.data
+                return Promise.resolve(result);
+
+            })
+            .catch((err: AxiosError) => {
+
+                //Google API error message
+                console.log(err?.response?.data?.error)
+
+                //Axios entire error message
+                console.log(err)
+
+                return Promise.reject(err);
+            });
+    }
+}
+
+module.exports.GooglePlacesAPI = GooglePlacesAPI;

--- a/backend/controllers/GooglePlacesAPI.ts
+++ b/backend/controllers/GooglePlacesAPI.ts
@@ -1,4 +1,4 @@
-import {AxiosError, AxiosResponse} from "axios";
+import axios, {AxiosError, AxiosResponse} from "axios";
 
 class GooglePlacesAPI {
 
@@ -6,15 +6,19 @@ class GooglePlacesAPI {
         require('dotenv').config();
     }
 
-    getGooglePlacesSearch(data: string): Promise<AxiosResponse<JSON>> {
+    getGooglePlacesSearch(data: string): Promise<JSON> {
         let dataURI: string = encodeURIComponent(data);
-        let axios = require('axios');
 
-        return axios.get('https://maps.googleapis.com/maps/api/place/findplacefromtext/json?'
-            + 'input=' + dataURI
-            + '&inputtype=textquery'
-            + '&fields=formatted_address,name,icon,place_id,types,photos'
-            + '&key=' + process.env.GOOGLE_PLACES_API_KEY
+        return axios.get('https://maps.googleapis.com/maps/api/place/findplacefromtext/json?',
+            {
+                params: {
+                    input: dataURI,
+                    inputtype: 'textquery',
+                    fields: 'business_status,formatted_address,geometry,name,place_id,' +
+                        'price_level,rating,user_ratings_total',
+                    key: process.env.GOOGLE_PLACES_API_KEY
+                }
+            }
         )
             .then((response: AxiosResponse) => {
 
@@ -34,17 +38,47 @@ class GooglePlacesAPI {
             });
     }
 
-    getGooglePlacesDetails(placeID: string): Promise<AxiosResponse<JSON>> {
-        let axios = require('axios');
-
-        return axios.get('https://maps.googleapis.com/maps/api/place/details/json?'
-            + 'place_id=' + placeID
-            + '&fields=business_status,url'
-            + '&key=' + process.env.GOOGLE_PLACES_API_KEY
+    getGooglePlacesDetails(placeID: string): Promise<JSON> {
+        return axios.get('https://maps.googleapis.com/maps/api/place/details/json?',
+            {
+                params: {
+                    place_id: placeID,
+                    fields: 'url,formatted_phone_number,opening_hours,website,review,photos',
+                    key: process.env.GOOGLE_PLACES_API_KEY
+                }
+            }
         )
             .then((response: AxiosResponse) => {
 
                 let result: JSON = response.data
+                return Promise.resolve(result);
+
+            })
+            .catch((err: AxiosError) => {
+
+                //Google API error message
+                console.log(err?.response?.data?.error)
+
+                //Axios entire error message
+                console.log(err)
+
+                return Promise.reject(err);
+            });
+    }
+
+    getGooglePlacesPhotos(photoReference: string): Promise<HTMLImageElement> {
+        return axios.get('https://maps.googleapis.com/maps/api/place/photo?',
+            {
+                params: {
+                    photoreference: photoReference,
+                    maxheight: 500,
+                    key: process.env.GOOGLE_PLACES_API_KEY
+                }
+            }
+        )
+            .then((response: AxiosResponse) => {
+
+                let result: HTMLImageElement = response.data;
                 return Promise.resolve(result);
 
             })
@@ -61,4 +95,4 @@ class GooglePlacesAPI {
     }
 }
 
-module.exports.GooglePlacesAPI = GooglePlacesAPI;
+export { GooglePlacesAPI };

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,8 @@
   },
   "homepage": "https://github.com/ubclaunchpad/foodies#readme",
   "dependencies": {
+    "axios": "^0.21.0",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1"
   },
   "devDependencies": {

--- a/backend/test/GooglePlacesAPI.test.ts
+++ b/backend/test/GooglePlacesAPI.test.ts
@@ -1,0 +1,34 @@
+import {AxiosError, AxiosResponse} from "axios";
+
+const {GooglePlacesAPI} = require('../controllers/GooglePlacesAPI');
+
+
+describe("tests for GooglePlacesAPI", function () {
+
+    let googlePlacesAPI = new GooglePlacesAPI();
+
+    beforeEach(function () {
+        require('dotenv').config();
+    });
+
+    test('Search for a place using restaurant name', () => {
+        return googlePlacesAPI.getGooglePlacesSearch("Rib and Chicken")
+            .then((result: AxiosResponse<JSON>) => {
+                console.log(result);
+            }).catch((error: AxiosError) => {
+                console.log(error);
+            });
+    });
+
+    test('Get details for a place using placeID', () => {
+        // placeID can only be retrieved from getGooglePlacesSearch
+        return googlePlacesAPI.getGooglePlacesDetails("ChIJb0n5cWl3hlQRIbVGYLiTEgE")
+            .then((result: AxiosResponse<JSON>) => {
+                console.log(result);
+            }).catch((error: AxiosError) => {
+                console.log(error);
+            });
+    });
+
+});
+

--- a/backend/test/GooglePlacesAPI.test.ts
+++ b/backend/test/GooglePlacesAPI.test.ts
@@ -1,7 +1,5 @@
 import {AxiosError, AxiosResponse} from "axios";
-
 const {GooglePlacesAPI} = require('../controllers/GooglePlacesAPI');
-
 
 describe("tests for GooglePlacesAPI", function () {
 
@@ -12,7 +10,7 @@ describe("tests for GooglePlacesAPI", function () {
     });
 
     test('Search for a place using restaurant name', () => {
-        return googlePlacesAPI.getGooglePlacesSearch("Rib and Chicken")
+        return googlePlacesAPI.getGooglePlacesSearch("Jinya")
             .then((result: AxiosResponse<JSON>) => {
                 console.log(result);
             }).catch((error: AxiosError) => {
@@ -24,6 +22,20 @@ describe("tests for GooglePlacesAPI", function () {
         // placeID can only be retrieved from getGooglePlacesSearch
         return googlePlacesAPI.getGooglePlacesDetails("ChIJb0n5cWl3hlQRIbVGYLiTEgE")
             .then((result: AxiosResponse<JSON>) => {
+                console.log(result);
+            }).catch((error: AxiosError) => {
+                console.log(error);
+            });
+    });
+
+    test("Get photo for a place using photoReference", () => {
+        // photoReference can only be retrieved from getGooglePlacesDetails or getGooglePlacesSearch
+        let photoReference = "CmRaAAAAG0iboUiJEm5FgUDCJcrSzqQ7NIqks4WRG-fOqExf1Wy8BvNf57uOfoJttukezQH8Fo" +
+            "Fp6xBo4HT07PqyBZGaSnv-zRakWaRpmm97BFKjlfigEHAOyXoHAKVharhRbkdKEhBt04bdMwjdPIABAINFpDuuGhQdc1q" +
+            "P733fSMvzjtPByT9ETO-71Q"
+
+        return googlePlacesAPI.getGooglePlacesPhotos(photoReference)
+            .then((result: AxiosResponse<HTMLImageElement>) => {
                 console.log(result);
             }).catch((error: AxiosError) => {
                 console.log(error);


### PR DESCRIPTION
The Yelp API is currently down so I didn't write endpoints for those! If it does end up getting fixed before Saturday, I'll try to add those in. I wrote tests that just print the results so you can see what it returns.

The two endpoints define a call for GooglePlacesSearch and GooglePlacesDetails (Search is needed to get a few of the fields as well as the placeID needed for the call to Details)

The format is slightly messy for the URLs in the GET requests because it wasn't allowing me to format it in a parameters object but if anyone has a clue on how to make it cleaner and if we end up keeping these calls, feel free to let me know! 

I just set a few of the fields that we'll most likely need to use. There is quite a number of discussions that we'll have to have regarding which API and what fields we want given our current contstraints. 

Please refer to this document for more information- [Google Places vs. Yelp APIs](https://docs.google.com/document/d/1VB1m5T601XZMaO-l-brTVzfyISdjWBng9krJK-UmBUw/edit?usp=sharing)

To test, you'll have to get your own key for now from Google Cloud and paste it into your .ENV with key "GOOGLE_PLACES_API_KEY=" 

