### PR TITLE
Added endpoints for Google Maps for zoom, center, and markers

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^14.14.3",
     "@types/react": "^16.9.53",
     "@types/react-dom": "^16.9.8",
+    "google-maps-react": "^2.0.6",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-scripts": "3.4.4",

--- a/frontend/src/MapContainer.js
+++ b/frontend/src/MapContainer.js
@@ -1,0 +1,49 @@
+import React, { Component } from 'react';
+import { Map, GoogleApiWrapper, Marker} from 'google-maps-react';
+
+const mapStyles = {
+  width: '100%',
+  height: '100%',
+};
+
+class MapContainer extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      stores: [{lat: 47.49855629475769, lng: -122.14184416996333},
+              {latitude: 47.359423, longitude: -122.021071},
+              {latitude: 47.2052192687988, longitude: -121.988426208496},
+              {latitude: 47.6307081, longitude: -122.1434325},
+              {latitude: 47.3084488, longitude: -122.2140121},
+              {latitude: 47.5524695, longitude: -122.0425407}]
+    }
+  }
+
+  displayMarkers = () => {
+    return this.state.stores.map((store, index) => {
+      return <Marker key={index} id={index} position={{
+       lat: store.latitude,
+       lng: store.longitude
+     }}
+     onClick={() => console.log("Click")} />
+    })
+  }
+
+  render() {
+    return (
+      <Map
+        google={this.props.google}
+        zoom={8}
+        style={mapStyles}
+        initialCenter={{ lat: 47.444, lng: -122.176}}
+      >
+        {this.displayMarkers()}
+      </Map>
+    );
+  }
+}
+
+export default GoogleApiWrapper({
+  apiKey: process.env.REACT_APP_GOOGLE_MAPS_API_KEY
+})(MapContainer);

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4852,6 +4852,11 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+google-maps-react@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/google-maps-react/-/google-maps-react-2.0.6.tgz#0473356207ab6b47227b393b89e4b83f6eab06da"
+  integrity sha512-M8Eo9WndfQEfxcmm6yRq03qdJgw1x6rQmJ9DN+a+xPQ3K7yNDGkVDbinrf4/8vcox7nELbeopbm4bpefKewWfQ==
+
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"


### PR DESCRIPTION
The google-maps-react module was used to easily render a map by providing data for the "zoom" field and longitude and latitude data for the "initialCenter" field. Markers can be displayed by giving each marker a longitude and latitude as well. As this is the case, it's best to have the API call in the frontend, but the data being programmatically decided by the backend.

As with the Google Places API, a Google Cloud key is needed to test with the Google Maps API, and this key should be placed in a .env file in the src folder with the line:
REACT_APP_GOOGLE_MAPS_API_KEY=

Resolves #13 