### PR TITLE
Fixed bug with DTO date

### DIFF
--- a/backend/src/main/controller/PromotionController.ts
+++ b/backend/src/main/controller/PromotionController.ts
@@ -89,7 +89,6 @@ export class PromotionController {
         promotionDTO.discount.discountType,
         promotionDTO.discount.discountValue
       );
-      const expirationDate = new Date(promotionDTO.expirationDate);
       const promotion = new Promotion(
         user,
         discount,
@@ -98,7 +97,7 @@ export class PromotionController {
         promotionDTO.cuisine,
         promotionDTO.name,
         promotionDTO.description,
-        expirationDate
+        promotionDTO.expirationDate
       );
 
       const result = await getCustomRepository(PromotionRepository).save(

--- a/backend/src/main/repository/PromotionRepository.ts
+++ b/backend/src/main/repository/PromotionRepository.ts
@@ -51,7 +51,7 @@ export class PromotionRepository extends Repository<Promotion> {
 
     if (promotionQuery?.expirationDate) {
       queryBuilder.andWhere('promotion.expirationDate >= :date', {
-        date: new Date(promotionQuery.expirationDate),
+        date: promotionQuery.expirationDate,
       });
     }
 


### PR DESCRIPTION
DTO will already create a Date object automatically for us, there was no difference between `new Date(promotionDTO.expirationDate)` vs `promotionDTO.expirationDate`