### PR TITLE
Optimized tests

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -67,6 +67,18 @@ This will run any migrations in the `/migrations` folder. Currently `ormconfig.j
 yarn run run_migration
 ```
 
+## Running unit tests
+
+If you want to run all tests in IntelliJ, add this new configuration. It's very important you specify
+the working directory as specified because TypeORM config needs the correct directory to find all the entities, migrations, subcribers etc.
+![image](https://user-images.githubusercontent.com/49849754/99886688-66ff8080-2bf3-11eb-88b1-2cb9879988db.png)
+
+You can also run tests using this command
+
+```
+yarn run test
+```
+
 ## Local development (without docker)
 
 ### Change ormconfig.json
@@ -76,10 +88,12 @@ Find `ormconfig.json` and change the following line to `host: localhost`
 ### Using Intellij
 
 Make sure you created the databases first.
-Intellij can show you your databases and tables. Go to the `Database` tab and add a new data source.  
+Intellij can show you your databases and tables. Go to the `Database` tab and add a new data source.
+
 ![image](https://user-images.githubusercontent.com/49849754/98451666-bfffec80-20fc-11eb-9165-8100d3a3dd41.png)
 
 Fill out with the username and password respectively
+
 ![image](https://user-images.githubusercontent.com/49849754/98451683-e4f45f80-20fc-11eb-8866-9dc21f3624d0.png)
 
 You should now be able to see all the databases and tables.

--- a/backend/README.md
+++ b/backend/README.md
@@ -88,7 +88,7 @@ Find `ormconfig.json` and change the following line to `host: localhost`
 ### Using Intellij
 
 Make sure you created the databases first.
-Intellij can show you your databases and tables. Go to the `Database` tab and add a new data source.
+IntelliJ can show you your databases and tables. Go to the `Database` tab and add a new data source.
 
 ![image](https://user-images.githubusercontent.com/49849754/98451666-bfffec80-20fc-11eb-9165-8100d3a3dd41.png)
 

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,4 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  maxWorkers: 1,
+  testMatch: ['**/__tests__/**/*.ts?(x)', '**/?(*.)+(spec|test).ts?(x)'],
 };

--- a/backend/src/test/repository/BaseRepositoryTest.ts
+++ b/backend/src/test/repository/BaseRepositoryTest.ts
@@ -1,9 +1,9 @@
-import { Connection, createConnection } from 'typeorm';
+import { createConnection, EntityMetadata, getConnection } from 'typeorm';
 
 // use this class whenever we want to write unit/integration tests that interact with foodies_test database.
-export class BaseRepositoryTest {
-  static establishTestConnection(): Promise<Connection> {
-    return createConnection({
+const connection = {
+  async create(): Promise<void> {
+    await createConnection({
       type: 'postgres',
       host: 'localhost',
       port: 5432,
@@ -23,5 +23,23 @@ export class BaseRepositoryTest {
         subscribersDir: 'src/main/subscriber',
       },
     });
-  }
-}
+  },
+
+  async close(): Promise<void> {
+    await this.clear();
+    await getConnection().close();
+  },
+
+  async clear(): Promise<void> {
+    const connection = getConnection();
+    const entities = connection.entityMetadatas;
+
+    const promises = entities.map(async (entity: EntityMetadata) => {
+      const repository = connection.getRepository(entity.name);
+      return repository.query(`DELETE FROM ${entity.tableName}`);
+    });
+    await Promise.all(promises);
+  },
+};
+
+export default connection;

--- a/backend/src/test/repository/DiscountRepository.test.ts
+++ b/backend/src/test/repository/DiscountRepository.test.ts
@@ -1,20 +1,23 @@
-import { getConnection, getCustomRepository } from 'typeorm';
+import { getCustomRepository } from 'typeorm';
 import { discounts_sample } from '../../main/resources/Data';
-import { BaseRepositoryTest } from './BaseRepositoryTest';
+import connection from './BaseRepositoryTest';
 import { Discount } from '../../main/entity/Discount';
 import { DiscountRepository } from '../../main/repository/DiscountRepository';
 
 describe('Unit tests for DiscountRepository', function () {
   let discountRepository: DiscountRepository;
-  beforeEach(() => {
-    return BaseRepositoryTest.establishTestConnection().then(() => {
-      discountRepository = getCustomRepository(DiscountRepository);
-    });
+
+  beforeAll(async () => {
+    await connection.create();
   });
 
-  afterEach(() => {
-    const conn = getConnection();
-    return conn.close();
+  afterAll(async () => {
+    await connection.close();
+  });
+
+  beforeEach(async () => {
+    await connection.clear();
+    discountRepository = getCustomRepository(DiscountRepository);
   });
 
   test('Should not be able to create discount without promotion', async () => {

--- a/backend/src/test/repository/EntityIntegration.test.ts
+++ b/backend/src/test/repository/EntityIntegration.test.ts
@@ -1,7 +1,7 @@
-import { getConnection, getCustomRepository } from 'typeorm';
+import { getCustomRepository } from 'typeorm';
 import { promotions_sample, users_sample } from '../../main/resources/Data';
 import { UserRepository } from '../../main/repository/UserRepository';
-import { BaseRepositoryTest } from './BaseRepositoryTest';
+import connection from './BaseRepositoryTest';
 import {
   PromotionRepository,
   PromotionWithRank,
@@ -20,18 +20,21 @@ describe('Integration tests for all entities', function () {
   let promotionRepository: PromotionRepository;
   let discountRepository: DiscountRepository;
   let savedPromotionRepository: SavedPromotionRepository;
-  beforeEach(() => {
-    return BaseRepositoryTest.establishTestConnection().then(() => {
-      userRepository = getCustomRepository(UserRepository);
-      promotionRepository = getCustomRepository(PromotionRepository);
-      discountRepository = getCustomRepository(DiscountRepository);
-      savedPromotionRepository = getCustomRepository(SavedPromotionRepository);
-    });
+
+  beforeAll(async () => {
+    await connection.create();
   });
 
-  afterEach(() => {
-    const conn = getConnection();
-    return conn.close();
+  afterAll(async () => {
+    await connection.close();
+  });
+
+  beforeEach(async () => {
+    await connection.clear();
+    userRepository = getCustomRepository(UserRepository);
+    promotionRepository = getCustomRepository(PromotionRepository);
+    discountRepository = getCustomRepository(DiscountRepository);
+    savedPromotionRepository = getCustomRepository(SavedPromotionRepository);
   });
 
   test('Should not be able to save a promotion if user is not saved', async () => {

--- a/backend/src/test/repository/UserRepository.test.ts
+++ b/backend/src/test/repository/UserRepository.test.ts
@@ -1,20 +1,23 @@
-import { getConnection, getCustomRepository } from 'typeorm';
+import { getCustomRepository } from 'typeorm';
 import { User } from '../../main/entity/User';
 import { users_sample } from '../../main/resources/Data';
 import { UserRepository } from '../../main/repository/UserRepository';
-import { BaseRepositoryTest } from './BaseRepositoryTest';
+import connection from './BaseRepositoryTest';
 
 describe('Unit tests for UserRepository', function () {
   let userRepository: UserRepository;
-  beforeEach(() => {
-    return BaseRepositoryTest.establishTestConnection().then(() => {
-      userRepository = getCustomRepository(UserRepository);
-    });
+
+  beforeAll(async () => {
+    await connection.create();
   });
 
-  afterEach(() => {
-    const conn = getConnection();
-    return conn.close();
+  afterAll(async () => {
+    await connection.close();
+  });
+
+  beforeEach(async () => {
+    await connection.clear();
+    userRepository = getCustomRepository(UserRepository);
   });
 
   test('Should be able to store a user and successfully retrieve the same user', async () => {


### PR DESCRIPTION
Optimized our integration/unit tests to run faster and fixed bug where we cannot run all tests at once

_Optimizing test_

- The trick here is the `BaseRepositoryTest.ts`. Before for every test that interacts with the `foodies_test` database, we were creating a new connection **each time** a test began. But this was very slow.
- Now, each test suite creates only **one** connection for all the tests running. And before each test begins, we manually clear the database by executing SQL DELETE statements to delete from all the tables, rather than dropping the connection and restarting a new connection (which would drop all the tables).

Our longest test class is `EntityIntegrationTest.ts`. This is how long it took before:
![image](https://user-images.githubusercontent.com/49849754/99886964-649e2600-2bf5-11eb-98db-778351ad7aaa.png)
This is how long it takes now, we have optimized the tests to be almost **8x faster**
![image](https://user-images.githubusercontent.com/49849754/99886966-69fb7080-2bf5-11eb-9ffb-168fb9127d15.png)

_Running all tests at once_
- see the README.md for instructions now
- we also fixed the bug, so now running `yarn run test` will succeed

Now all our tests take about 1 second
![image](https://user-images.githubusercontent.com/49849754/99887030-d8d8c980-2bf5-11eb-9a38-ddabd8b2c358.png)

Before all tests took this long
![image](https://user-images.githubusercontent.com/49849754/99887222-65d05280-2bf7-11eb-8ea2-8d72541ccca4.png)

Credits to https://dev.to/caiulucas/tests-with-jest-and-typeorm-4j1l for the idea!